### PR TITLE
Add CHE regional terms

### DIFF
--- a/regional/CHE-core-terms.md
+++ b/regional/CHE-core-terms.md
@@ -6,14 +6,16 @@
 
 # Safe Harbor
 
-Consequences of complying with the Code of Conduct (Legal Safe Harbor)
+When conducting vulnerability research according to this policy, we:
 
-1. The owner will not take civil action or file a complaint with law enforcement authorities against participants for accidental, good faith violations of the Code of Conduct
+1. will not take civil action or file a complaint with law enforcement authorities against you for accidental, good faith violations of the policy
 
-2. The owner interprets activities by participants that comply with the Code of Conduct as authorized access under the Swiss Penal Code. This includes Swiss Penal Code paragraphs 143, 143<sup>bis</sup> and 144<sup>bis</sup>.
+2. interpret activities that comply with the policy as authorized access under the Swiss Penal Code. This includes Swiss Penal Code paragraphs 143, 143<sup>bis</sup> and 144<sup>bis</sup>.
 
-3. The owner will not file a complaint against participants for trying to circumvent the security measures deployed in order to protect the services in-scope for this program.
+3. will not file a complaint against you for trying to circumvent the security measures deployed in order to protect the services in-scope according this policy.
 
-4. If legal action is initiated by a third party against a participant and the participant has complied with the Code of Conduct as outlined in this document, the owner will take the necessary measures to make it known to the authorities that such participant’s actions have been conducted in compliance with this policy.
+If legal action is initiated by a third party against you and you have complied with the policy as outlined in this document, we will take the necessary measures to make it known to the authorities that your actions have been conducted in compliance with this policy.
 
-5. Any non-compliance with the Code of Conduct may result in exclusion from the program. For minor breaches, a warning may be issued. For severe breaches, the organizers reserve the right to file criminal charges.
+You are expected, as always, to comply with all applicable laws.
+
+If at any time you have concerns or are uncertain whether your security research is consistent with this policy, please submit a report through one of our Official Channels before going any further.

--- a/regional/CHE-core-terms.md
+++ b/regional/CHE-core-terms.md
@@ -1,0 +1,19 @@
+# Introduction
+
+# Expectations
+
+# Ground Rules
+
+# Safe Harbor
+
+Consequences of complying with the Code of Conduct (Legal Safe Harbor)
+
+1. The owner will not take civil action or file a complaint with law enforcement authorities against participants for accidental, good faith violations of the Code of Conduct
+
+2. The owner interprets activities by participants that comply with the Code of Conduct as authorized access under the Swiss Penal Code. This includes Swiss Penal Code paragraphs 143, 143<sup>bis</sup> and 144<sup>bis</sup>.
+
+3. The owner will not file a complaint against participants for trying to circumvent the security measures deployed in order to protect the services in-scope for this program.
+
+4. If legal action is initiated by a third party against a participant and the participant has complied with the Code of Conduct as outlined in this document, the owner will take the necessary measures to make it known to the authorities that such participant’s actions have been conducted in compliance with this policy.
+
+5. Any non-compliance with the Code of Conduct may result in exclusion from the program. For minor breaches, a warning may be issued. For severe breaches, the organizers reserve the right to file criminal charges.


### PR DESCRIPTION
Dear disclose.io team,
we from Bug Bounty Switzerland would like to contribute the Swiss version of the legal safe harbor terms (from https://github.com/Bug-Bounty-Switzerland/policies-terms) to your great project. The terms have been developed by members of Bug Bounty Switzerland originally and they're being used as de-facto standard throughout Switzerland (Swiss Post, e-voting public intrusion test, even the Swiss government is using them for their public tests in a slightly modified version).

We'd like to make those terms as accessible as possible and think contributing them to disclose.io could make a real difference!